### PR TITLE
hide the desktop entry

### DIFF
--- a/data/ind.ie.Gnomit.desktop.in
+++ b/data/ind.ie.Gnomit.desktop.in
@@ -6,3 +6,4 @@ Type=Application
 Categories=Development;Utility;RevisionControl;TextEditor;GNOME;GTK;
 StartupNotify=true
 Icon=ind.ie.Gnomit
+NoDisplay=true


### PR DESCRIPTION
Since gnomit does not run "standalone" I think it makes sense to hide the desktop entry.