### PR TITLE
Update flatpak json

### DIFF
--- a/org.small_tech.Gnomit.json
+++ b/org.small_tech.Gnomit.json
@@ -10,7 +10,7 @@
     "finish-args" : [
         "--filesystem=host",
         /* X11 + XShm access */
-        "--share=ipc", "--socket=x11", "--socket=fallback-x11",
+        "--share=ipc", "--socket=fallback-x11",
         /* Wayland access */
         "--socket=wayland"
     ],

--- a/org.small_tech.Gnomit.json
+++ b/org.small_tech.Gnomit.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.small_tech.Gnomit",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.36",
+    "runtime-version" : "3.38",
     "sdk" : "org.gnome.Sdk",
     "command" : "org.small_tech.Gnomit",
     "x-run-args" : [
@@ -41,8 +41,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.3.tar.xz",
-                    "sha256" : "5ae514dd0216be069176accf6d0049d6a01cfa6a50df4bc06be85f7080b62de8"
+                    "url" : "https://download.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz",
+                    "sha256" : "dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd"
                 }
             ],
             "cleanup" : [


### PR DESCRIPTION
Rebase on gnome 3.38 instead of 3.36 and gjs on 1.9.1 instead of 1.8.3.